### PR TITLE
Review

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ This section is to be followed once the installation and set-up has been complet
 | How to access Mongo DB and create the initial DB configurations    | [mongo-connect-configure](system-configuration/1-mongodb-config.md) |
 | Creating & uploading Studies and Surveys for the Influenzanet platform    | [create-study-surveys](system-configuration/2-create-study-surveys.md) |
 | How to create and upload Email Templates to be sent out by the platform    | [create-upload-emails](system-configuration/3-email-setup.md) |
-| Setting up mailing service configurations| [mailing-configuration](system-configuration/5-mailing-config.md) |
 | Configuring layouts and pages in the web-ui| [web-ui-configuration](system-configuration/4-web-config.md) |
+| Setting up mailing service configurations| [mailing-configuration](system-configuration/5-mailing-config.md) |
 
 ### 3. How to make changes and re-deploy
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a brief guide to the different repositories present within the scope of Influenzanet. It also acts as the WIKI to the major actions - installation, configurations, updates and maintenance; that can be performed with Influenzanet.
 
-**Note**: We refer to each repository that forms a part of the Influenzanet platform with the term 'service'. Even though there is not a one to one correspondence between repositories and services, it helps make our explanation easier.
+**NOTE**: We refer to each repository that forms a part of the Influenzanet platform with the term 'service'. Even though there is not a one to one correspondence between repositories and services, it helps make our explanation easier.
 
 First we take a look at the different parts of Influenzanet. Here, we use the term repository to specify a "GitHub repository" unless stated otherwise.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a brief guide to the different repositories present within the scope of 
 
 **Note**: We refer to each repository that forms a part of the Influenzanet platform with the term 'service'. Even though there is not a one to one correspondence between repositories and services, it helps make our explanation easier.
 
-First we take a look at the different parts of Influenzanet. Here, we use the term repository to specify a "Github repository" unless stated otherwise.
+First we take a look at the different parts of Influenzanet. Here, we use the term repository to specify a "GitHub repository" unless stated otherwise.
 
 ## Platform services
 
@@ -49,7 +49,7 @@ In this section we explain the following tasks:
 
 | Section Topic        | Instruction File  |
 | -------------- | ----------------:|
-| Starting from scratch - set up the required Github repositories    | [repository-creation](installation/1-repository-creation.md) |
+| Starting from scratch - set up the required GitHub repositories    | [repository-creation](installation/1-repository-creation.md) |
 | Set-up dockerhub and image builds   | [dockerhub-setup](installation/2-dockerhub-setup.md) |
 | Prepare a Google Kubernetes Environment and Install Influenzanet    | [gke-influenzanet-installation](installation/3-install-influenzanet-gke.md) |
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
-# Influenzanet-getting-started
+# influenzanet-setup-guide
+
 This is a brief guide to the different repositories present within the scope of Influenzanet. It also acts as the WIKI to the major actions - installation, configurations, updates and maintenance; that can be performed with Influenzanet.
 
-**Note**: We refer to each repository that forms a part of Influenzanet with the term 'service'. While not all are services in the true sense of the word, it helps make our explanation easier.
+**Note**: We refer to each repository that forms a part of the Influenzanet platform with the term 'service'. Even though there is not a one to one correspondence between repositories and services, it helps make our explanation easier.
 
 First we take a look at the different parts of Influenzanet. Here, we use the term repository to specify a "Github repository" unless stated otherwise.
 
-# Current Service Information
+## Platform services
+
 These repositories form the core services of the Influenzanet platform.
 
 | Service        | Repository           | Function  |
 | -------------- | -------------------- | ----------------:|
 | participant-api      | api-gateway | Default backend API Gateway for web participants |
-| management-api      | api-gateway | BAckend API Gateway for the researchers and admins of Influenzanet |
-| study-service      | study-service | Backend service responsible for mananging studies and surveys in the system |
+| management-api      | api-gateway | Backend API Gateway for the researchers and admins of Influenzanet |
+| study-service      | study-service | Backend service responsible for managing studies and surveys in the system |
 | user-management-service      | user-management-service | Backed service for the management of users in the system |
 | email-client-service      | messaging-service | Backend service responsible for sending emails out of the system |
 | message-scheduler      | messaging-service | Backend service that triggers events to send out emails periodically|
@@ -20,53 +22,50 @@ These repositories form the core services of the Influenzanet platform.
 | logging-service      | logging-service | Backend service responsible for logging into DB information from all services |
 | participant-webapp      | participant-webapp  | React based front-end of the Influenzanet platform |
 
+## Supplementary repositories
 
-# Supplementary Service Information
-These repositories act as supporting services and scripts to help set up, perform configurations and/or deploy the Influenzanet platform.
+These repositories act as supporting applications and scripts to help set up, perform configurations and/or deploy the Influenzanet platform.
 
-| Service        | Repository           | Function  |
-| -------------- | -------------------- | ----------------:|
-| study-manager    | study-manager-app | Contains a React Application to help build surveys for researchers and export it as a JSON |
-| admin-scripts    | admin-scripts | Scripts to create studies, upload surveys, upload email templates, and perform config changes on a running Influenzanet platform |
-| cluster-management     | cluster-management | Scripts that help install Influenzanet on a GKE cluster, contains scripts to also stop all deployed services on a running cluster and restart them |
+| Repository           | Function  |
+| -------------------- | ----------------:|
+| study-manager-app | Contains a React Application to help build surveys for researchers and export it as a JSON |
+| admin-scripts | Scripts to create studies, upload surveys, upload email templates, and perform config changes on a running Influenzanet platform (*private repository*) |
+| cluster-management | Scripts that help install Influenzanet on a GKE cluster, contains scripts to also stop all deployed services on a running cluster and restart them |
 
-
-# Walkthrough Sections
+## Walkthrough Sections
 
 The walkthrough sections are divided into three main categories:
 
-1. Installation and Set-up
-2. Initial system configurations
-3. How to make changes & re-deploy
-4. Maintenance Activities
+1. [Installation and Set-up](#1-installation-and-set-up)
+2. [Initial system configurations](#2-initial-system-configurations)
+3. [How to make changes & re-deploy](#3-how-to-make-changes-and-re-deploy)
+4. [Maintenance Activities](#4-maintenance-activities)
 
 Each section consists of topics that are to be followed in the provided order. For sections like maintenance activities you can jump directly to the area of concern.
 
-## Installation and Set-up
+### 1. Installation and Set-up
 
 In this section we explain the following tasks:
 
 | Section Topic        | Instruction File  |
 | -------------- | ----------------:|
-| Starting from scratch - set up the required Github repositories    | [repository-creation](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/installation/1-repository-creation.md) |
-| Set-up dockerhub and automated builds   | [dockerhub-setup](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/installation/2-dockerhub-setup.md) |
-| Prepare a Google Kubernetes Environment and Install Influenzanet    | [gke-influenzanet-installation](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/installation/3-install-influenzanet-gke.md) |
+| Starting from scratch - set up the required Github repositories    | [repository-creation](installation/1-repository-creation.md) |
+| Set-up dockerhub and image builds   | [dockerhub-setup](installation/2-dockerhub-setup.md) |
+| Prepare a Google Kubernetes Environment and Install Influenzanet    | [gke-influenzanet-installation](installation/3-install-influenzanet-gke.md) |
 
-## Initial System Configurations
+### 2. Initial System Configurations
 
-This section is to be followed once the installation and set-up has been completed.
-
-The topics covered are as follows:
+This section is to be followed once the installation and set-up has been completed. The topics covered are as follows:
 
 | Section Topic        | Instruction File  |
 | -------------- | ----------------:|
-| How to access Mongo DB and create the initial DB configurations    | [mongo-connect-configure](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/system-configuration/1-mongodb-config.md) |
-| Creating & uploading Studies and Surveys for the Influenzanet platform    | [create-study-surveys](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/system-configuration/2-create-study-surveys.md) |
-| How to create and upload Email Templates to be sent out by the platform    | [create-upload-emails](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/system-configuration/3-email-setup.md) |
-| Setting up mailing service configurations| [mailing-configuration](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/system-configuration/5-mailing-config.md) |
-| Configuring layouts and pages in the web-ui| [web-ui-configuration](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/system-configuration/4-web-config.md) |
+| How to access Mongo DB and create the initial DB configurations    | [mongo-connect-configure](system-configuration/1-mongodb-config.md) |
+| Creating & uploading Studies and Surveys for the Influenzanet platform    | [create-study-surveys](system-configuration/2-create-study-surveys.md) |
+| How to create and upload Email Templates to be sent out by the platform    | [create-upload-emails](system-configuration/3-email-setup.md) |
+| Setting up mailing service configurations| [mailing-configuration](system-configuration/5-mailing-config.md) |
+| Configuring layouts and pages in the web-ui| [web-ui-configuration](system-configuration/4-web-config.md) |
 
-## How to make changes and re-deploy
+### 3. How to make changes and re-deploy
 
 Any configuration, content, design changes or bug-fixes will require the service where the change has occurred to be re-deployed for it show up in the live version of the platform. This sections covers all the topics involved in making such changes on the fly with a running version of the platform.
 
@@ -74,16 +73,16 @@ Topics covered here are:
 
 | Section Topic        | Instruction File  |
 | -------------- | ----------------:|
-| Types of code changes  | [change-types](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/redeploying-changes/1-change-types.md) |
-| Automated builds and re-deployment to Google cloud   | [build-and-redeploy](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/redeploying-changes/2-build-and-redeploy.md) |
-| Roll-back in case of errors     | [rollback-errors](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/redeploying-changes/3-rollback-errors.md) |
+| Types of code changes  | [change-types](redeploying-changes/1-change-types.md) |
+| Automated builds and re-deployment to Google cloud   | [build-and-redeploy](redeploying-changes/2-build-and-redeploy.md) |
+| Roll-back in case of errors     | [rollback-errors](redeploying-changes/3-rollback-errors.md) |
 
-## Maintenance Activities
+### 4. Maintenance Activities
 
-Activites to be scheduled over the life-cycle of the Influenzanet-platform:
+Activities to be scheduled over the life-cycle of the Influenzanet-platform:
 
 | Section Topic        | Instruction File  |
 | -------------- | ----------------:|
-| Maintenance Activity checklist | [checklist](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/maintenance/1-checklist.md) |
-| Issue resoution | [issue-resolution](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/maintenance/2-issue-resolution.md) |
-| Scaling resource allocations to cope with loads | [scaling-resources](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/maintenance/3-resource-scaling.md) |
+| Maintenance Activity checklist | [checklist](maintenance/1-checklist.md) |
+| Issue resoution | [issue-resolution](maintenance/2-issue-resolution.md) |
+| Scaling resource allocations to cope with loads | [scaling-resources](maintenance/3-resource-scaling.md) |

--- a/installation/1-repository-creation.md
+++ b/installation/1-repository-creation.md
@@ -1,6 +1,6 @@
 # Creating the repositories
 
-To begin with, it is advisable to set up an institution account on Github ideally with the country of deployment in mind. For example: `Influenzanet-IT`.
+To begin with, it is advisable to set up an institution account on GitHub ideally with the country of deployment in mind. For example: `Influenzanet-IT`.
 
 ##  Influenzanet
 
@@ -12,15 +12,15 @@ The major components and services of the Influenzanet platform are centrally hos
 
 ### Setting up the repositories
 
-For each of the relevant services listed in the table in the central [README.md](../README.md), navigate to the repository hosted at Influenzanet. Make sure you are logged into the institution account you created on Github. Fork each of the repositories in the table into your institutions personal github account. Once completed you should have 9 forked repositories (namely: api-gateway, study-service, user-management-service, messaging-service, logging-service, participant-webapp, study-manager-app, admin-scripts, cluster-management).
+For each of the relevant services listed in the table in the central [README.md](../README.md), navigate to the repository hosted at Influenzanet. Make sure you are logged into the institution account you created on GitHub. Fork each of the repositories in the table into your institutions personal GitHub account. Once completed you should have 9 forked repositories (namely: api-gateway, study-service, user-management-service, messaging-service, logging-service, participant-webapp, study-manager-app, admin-scripts, cluster-management).
 
 **For example:** to add the participant API and management API, navigate to the [api-gateway](https://github.com/influenzanet/api-gateway) repository in Influenzanet, click on the fork icon to create a forked copy into your GitHub account.
 
 ### Manage Access 
 
-Once your repositories are forked, you can provide access to individual developers or teams that are working to deploy the Influenzanet platform. This has to be done for each of the forked repositories. If the decision is made to make changes only through the main Github account you have created (eg: `Influweb-IT`) this step can be skipped. 
+Once your repositories are forked, you can provide access to individual developers or teams that are working to deploy the Influenzanet platform. This has to be done for each of the forked repositories. If the decision is made to make changes only through the main GitHub account you have created (eg: `Influweb-IT`) this step can be skipped. 
 
-Permissions for access can be granted by navigating to the forked repository, click on the settings >> manage access >>invite a collaborator (this is visible only to the owner of the main Github account)
+Permissions for access can be granted by navigating to the forked repository, click on the settings >> manage access >>invite a collaborator (this is visible only to the owner of the main GitHub account)
 
 ### Maintaining sync with Influenzanet
 

--- a/installation/1-repository-creation.md
+++ b/installation/1-repository-creation.md
@@ -1,37 +1,35 @@
-
 # Creating the repositories
 
-  
-
-To begin, it is advisable to set up an institution account on Github ideally with the country of deployment in mind. For example: influenzanet, influenzanetIT. 
+To begin with, it is advisable to set up an institution account on Github ideally with the country of deployment in mind. For example: `Influenzanet-IT`.
 
 ##  Influenzanet
 
-The major components and services of the influenzanet platform are centrally hosted under the [Influenzanet](https://github.com/influenzanet) collection of respositories. The relevant respositories that we need are indicated in two tables in the central [Readme](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/README.md)*. For the deployment of a specific country, we will be creating forks of these repositories and making changes to these forks. Periodically we will also be creating pull requests to the central repositories in Influenzanet to maintain synchronisation and to regularly take in updates.
- 
+The major components and services of the Influenzanet platform are centrally hosted under the [influenzanet](https://github.com/influenzanet) collection of repositories. The relevant repositories that we need are indicated in two tables in the central [README.md](../README.md)* file. For the deployment of a specific country, we will be creating forks of these repositories and making changes to these forks. Periodically, we will also be creating pull requests to the central repositories in [influenzanet](https://github.com/influenzanet) to maintain synchronization and to regularly take in updates.
+
 \* Look for the name listed under the column "Repository"
 
 ## Creating and managing repositories
 
 ### Setting up the repositories
 
-For each of the relavant services listed in the table in the central [Readme](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/README.md) navigate to the repository hosted at Influenzanet. Make sure you are logged into the institution account you created on Github. Fork each of the respositories in the table into your institutions personal github account. Once completed you should have 9 forked repositories (namely: api-gateway, study-service, user-management-service, messaging-service, logging-service, participant-webapp, study-manager-app).
+For each of the relevant services listed in the table in the central [README.md](../README.md), navigate to the repository hosted at Influenzanet. Make sure you are logged into the institution account you created on Github. Fork each of the repositories in the table into your institutions personal github account. Once completed you should have 9 forked repositories (namely: api-gateway, study-service, user-management-service, messaging-service, logging-service, participant-webapp, study-manager-app, admin-scripts, cluster-management).
 
-**For example:** To add the participant API and management API, navigate to the [api-gateway](https://github.com/influenzanet/api-gateway) repository in Influenzanet, click on the fork icon to create a forked copy into your GitHub account.
+**For example:** to add the participant API and management API, navigate to the [api-gateway](https://github.com/influenzanet/api-gateway) repository in Influenzanet, click on the fork icon to create a forked copy into your GitHub account.
 
 ### Manage Access 
 
-Once your respositories are forked, you can provide access to individual developers or teams that are working to deploy the influenzanet platform. This has to be done for each of the forked repositories. If the decision is made to make changes only through the main Github account you have created (for ex: influenzanet) this step can be skipped. 
+Once your repositories are forked, you can provide access to individual developers or teams that are working to deploy the Influenzanet platform. This has to be done for each of the forked repositories. If the decision is made to make changes only through the main Github account you have created (eg: `Influweb-IT`) this step can be skipped. 
 
-Permissions for access can be granted by navigating to the forked repository, click on the settings >> manage access >>invite a collaborator. (this is visible only to the main Github account)
+Permissions for access can be granted by navigating to the forked repository, click on the settings >> manage access >>invite a collaborator (this is visible only to the owner of the main Github account)
 
 ### Maintaining sync with Influenzanet
 
-Throughout the course of your individual deployment of influenzanet, there are going to be changes made to your forked repository that might need to be merged back into the main Influenzanet repository. To do so, generally create a pull request onto the Influenzanet repository from your fork using the official GitHub account. 
+Throughout the course of your individual deployment of Influenzanet, there are going to be changes made to your forked repository that might need to be merged back into the main Influenzanet repository. To do so, generally create a pull request onto the Influenzanet repository from your fork using the official GitHub account. 
 
-Similarly, there may also be new features or changes coming in from the main Influenzanet repository. Periodically merge these into your forked repository to avoid having to face issues in adopting in new features coming in from the Influenzanet repositories. 
+Similarly, there may also be new features or changes coming in from the main Influenzanet repository. Periodically merge these into your forked repository to avoid having to face issues in adopting in new features coming in from the Influenzanet repositories.
 
 ##  From forks to your local machine
 
-Most of the major tasks in configuring influenzanet for a particular deployment mainly involve the participant-webapp, study-manager-app repositories. It is useful to have a clone of these in your local machine (from the newly created forks) to continue work on setting up the platform. Individual developers are also free to clone all services as they see fit.
-**You will also need to clone the repository Influenzanet/admin-scripts to perform routine activities such as uploading templates, downloading weekly/intake responses. This is VERY IMPORTANT FOR THE DATA ANALYSIS**.
+Most of the major tasks in configuring Influenzanet for a particular deployment mainly involve the participant-webapp, study-manager-app repositories. It is useful to have a clone of these in your local machine (from the newly created forks) to continue work on setting up the platform. Individual developers are also free to clone all services as they see fit.
+
+**Next**: [Dockerhub Setup](../installation/2-dockerhub-setup.md)

--- a/installation/2-dockerhub-setup.md
+++ b/installation/2-dockerhub-setup.md
@@ -57,7 +57,7 @@ By default the build action must be run manually. This behaviour can be modified
 
 Action files make use of **secrets** to store Dockerhub authentication information. They are used by GitHub actions to login into the Dockerhub repository and push the newly built image.
 
-To configure secrets for a GitHub repository navigate to the settings of the repository  (eg: https://github.com/Influweb-IT/user-management-service/settings), and click on secrets. Here you can create new secrets for your repository.
+To configure secrets for a GitHub repository navigate to the settings of the repository  (eg: https://github.com/Influweb-IT/user-management-service), open the configuration page and click on secrets. Here you can create new secrets for your repository.
 
 **Organization secrets** will be visible to each repository in the organization. **Repository secrets** will be visible only to that particular repository.
 

--- a/installation/2-dockerhub-setup.md
+++ b/installation/2-dockerhub-setup.md
@@ -57,7 +57,7 @@ By default the build action must be run manually. This behaviour can be modified
 
 Action files make use of **secrets** to store Dockerhub authentication information. They are used by GitHub actions to login into the Dockerhub repository and push the newly built image.
 
-To configure secrets for a GitHub repository navigate to the settings of the repository  (ex: https://github.com/Influweb-IT/user-management-service/settings), and click on secrets. Here you can create new secrets for your repository.
+To configure secrets for a GitHub repository navigate to the settings of the repository  (eg: https://github.com/Influweb-IT/user-management-service/settings), and click on secrets. Here you can create new secrets for your repository.
 
 **Organization secrets** will be visible to each repository in the organization. **Repository secrets** will be visible only to that particular repository.
 
@@ -78,15 +78,15 @@ The different secrets needed for each of the GitHub Repositories are listed belo
 	 - DOCKER_USER (Organization secret)
 	 - DOCKER_PASSWORD (Organization secret)
 	 - DOCKER_ORGANIZATION (Organization secret)
-	 - DOCKER_MANAGEMENT_API_REPO_NAME: Name of the dockerhub image for management-api. (ex: management-api-image) (Repository secret)
-	 - DOCKER_PARTICIPANT_API_REPO_NAME: Name of the dockerhub image for participant-api. (ex: participant-api-image) (Repository secret)
+	 - DOCKER_MANAGEMENT_API_REPO_NAME: Name of the dockerhub image for management-api. (eg: management-api-image) (Repository secret)
+	 - DOCKER_PARTICIPANT_API_REPO_NAME: Name of the dockerhub image for participant-api. (eg: participant-api-image) (Repository secret)
  - **messaging-service**:
 	 - DOCKER_USER (Organization secret)
 	 - DOCKER_PASSWORD (Organization secret)
 	 - DOCKER_ORGANIZATION (Organization secret)
-	 - DOCKER_REPO_MS: Name of the dockerhub image for messaging-service (ex: messaging-service-image) (Repository secret)
-	 - DOCKER_REPO_MSC: Name of the dockerhub image for messaging-scheduler (ex: messaging-scheduler-image) (Repository secret)
-	 - DOCKER_REPO_EC: Name of the dockerhub image for email-client-service (ex: email-client-service-image) (Repository secret)
+	 - DOCKER_REPO_MS: Name of the dockerhub image for messaging-service (eg: messaging-service-image) (Repository secret)
+	 - DOCKER_REPO_MSC: Name of the dockerhub image for messaging-scheduler (eg: messaging-scheduler-image) (Repository secret)
+	 - DOCKER_REPO_EC: Name of the dockerhub image for email-client-service (eg: email-client-service-image) (Repository secret)
 
 Once the Dockerhub repositories and the secrets have been configured, you will notice that each repository can trigger a build by navigating to the actions tab on GitHub, selecting "Docker Image CI" and by clicking of the "run workflow" button. An easy method of identifying the different images is by using the version which is identical to the last tagged release in the respective GitHub repository. You can also choose to override the version being tagged and provide it through a manual input on triggering the workflow.
 

--- a/installation/2-dockerhub-setup.md
+++ b/installation/2-dockerhub-setup.md
@@ -1,49 +1,22 @@
-
 # Dockerhub Setup
 
-If a code/configuration/styling/markdown change occurs in any of the 6 repositories, the repositories in question needs to be re-built. Basically, this happens every time content of any kind is changed in the front end or in the back end. Here the term 're-built' refers to the process of creating a new ready-to-deploy version of the service (which we also call an image).
+If a code/configuration/styling/markdown change occurs in any of the 6 repositories hosting the services source code, the repository in question needs to be re-built. Basically, this has to happen every time content of any kind is changed in the front end or in the back end. Here the term 're-built' refers to the process of creating a new ready-to-deploy version of the service (ie: a docker image).
 
-The images created in this manner are all stored in a central dockerhub repository.
+The docker images created in this manner are all stored in a central dockerhub repository.
+
+The first time the Influenzanet platform is deployed for a specific country all the services images will have to be built in this way. 
 
 ## Pre-requisites
 
-To get started, a dockerhub account is needed where all the images can reside. To do so, go on to https://hub.docker.com/ and create a new account. (Example: A new dockerhub account by the name LOCAL_COUNTRY_NAME).
+To get started, a dockerhub repository is needed where all the images can reside. To do so, go on to https://hub.docker.com/ and create a new account. (Example: Influweb-IT).
 
-## Set up the required repositories
+## Configuring docker image builds
 
-Similar to the repositories created in Github, we will also be creating repositories to house the images of each service. This ends up becoming a catalog of different service images, along with the different versions available for each service.
+Each of the Github repositories comes with a Github Action associated with it. The github action is a file containing code to build a docker image and push this image to the previously created dockerhub repository.
 
-Note: Although 6 repositories exist in Github, on Dockerhub we create 9 repositories since API-Gateway and Messaging-Service are further split into 2 and 3 images respectively.
+The action file (present in the repository folder .github/workflows) generally contains the following:
 
-### Creating the repositories
-
-1. Sign into Dockerhub, cick on create repository.
-2. Give a suitable name, use table below for reference.
-3. Select visibility as "Public".
-4. Under Build Settings, select Connect to Github. Select the orgnisation and respository name under Github. Use the table below for reference.
-5. Click create and repeat the process for the rest of the images.
-
-The table of reference for Image names and Github repositories follows below:
-
-| Image Name       | Github Repository Name  |
-| -------------- | ----------------:|
-| participant-webapp     | participant-webapp |
-| management-api-image  | api-gateway |
-| participant-api-image  | api-gateway |
-| messaging-service-image  | messaging-service |
-| message-scheduler-image  | messaging-service |
-| email-client-service-image | messaging-service |
-| study-service-image | study-service |
-| user-management-image | user-management-service |
-| logging-service-image   | logging-service |
-
-
-## Configuring Automated Builds
-
-Most of the Github repositories comes with a Github Action associated with it. The github action, is a file containing code to build a docker image, and push this image to the dockerhub repository on every new commit. **This is needed to link the Github repository and the Docker service image.**
-
-The file (present in the folder REPOSITORY_NAME/.github/workflows) genrally contains the following:
-```
+```yaml
 name: Docker Image CI
 
 on:
@@ -78,43 +51,43 @@ jobs:
       run: docker push ${{secrets.DOCKER_ORGANIZATION}}/${{secrets.DOCKER_REPO_NAME}}:$REPO_VERSION
 ```
 
-This can be modified to detect commits or pull requests on different branches as needed. 
+By default the build action must be run manually. This behaviour can be modified to automatically build and push the image on Dockerhub when commits or pull requests are detected on specific branches. 
 
 ### Docker secrets
 
-Automated builds make use of **secrets** to store Dockerhub authentication information. This is used by Github actions to login to docker hub repository and push the newly built image to the hosted repository.
+Action files make use of **secrets** to store Dockerhub authentication information. They are used by Github actions to login into the Dockerhub repository and push the newly built image.
 
-To configure secrets for a Github repository navigate to the settings of the repo (ex: https://github.com/YOUR_LOCAL_FORK/user-management-service/settings), and click on secrets. Here you can create new secrets for your repository.
+To configure secrets for a Github repository navigate to the settings of the repository  (ex: https://github.com/Influweb-IT/user-management-service/settings), and click on secrets. Here you can create new secrets for your repository.
 
-NOTE: You need to be signed as the owner of the repository to add these secrets.
+**Organization secrets** will be visible to each repository in the organization. **Repository secrets** will be visible only to that particular repository.
 
 The different secrets needed for each of the Github Repositories are listed below:
 
- - **Participant-webapp**:
-	 - DOCKER_USER : Username for the account on dockerhub (Organizational level secret)
-	 - DOCKER_PASSWORD: Password for the account on dockerhub (Organizational level secret)
-	 - DOCKER_ORGANIZATION: Name of the organisation on dockerhub under which the repositories exist. (Ex: influenzanet) (Organizational level secret)
-	 - DOCKER_REPO_NAME: The actual name of the image repository to push to on dockerhub. (Ex:participant-webapp) (service-specific secret)
- - **Study-service**:
+ - **participant-webapp**:
+	 - DOCKER_USER : Username for the account on dockerhub (Organization secret)
+	 - DOCKER_PASSWORD: Password for the account on dockerhub (Organization secret)
+	 - DOCKER_ORGANIZATION: Name of the organization on dockerhub under which the repositories exist. (Ex: influenzanet) (Organization secret)
+	 - DOCKER_REPO_NAME: The actual name of the image repository to push to on dockerhub. (Ex:participant-webapp) (Repository secret)
+ - **study-service**:
 	 - Same fields as participant-webapp
- - **User-management-service**:
+ - **user-management-service**:
 	 - Same fields as the participant-webapp
- - **Logging-service**:
+ - **logging-service**:
 	 - Same fields as the participant-webapp
- -  **API-Gateway**:
-	 - DOCKER_USER
-	 - DOCKER_PASSWORD
-	 - DOCKER_ORGANIZATION
-	 - DOCKER_MANAGEMENT_API_REPO_NAME: Name of the dockerhub repository for management-api. (ex: management-api-image)
-	 - DOCKER_PARTICIPANT_API_REPO_NAME: Name of the dockerhub repository for participant-api. (ex: participant-api-image)
- - **Messaging-service**:
-	 - DOCKER_USER
-	 - DOCKER_PASSWORD
-	 - DOCKER_ORGANIZATION
-	 - DOCKER_REPO_MS: Name of the dockerhub repository for messaging-service (ex: messaging-service-image)
-	 - DOCKER_REPO_MSC: Name of the dockerhub repository for messaging-scheduler (ex: messaging-scheduler-image)
-	 - DOCKER_REPO_EC: Name of the dockerhub repository for email-client-service (ex: email-client-service-image)
+ -  **api-gateway**:
+	 - DOCKER_USER (Organization secret)
+	 - DOCKER_PASSWORD (Organization secret)
+	 - DOCKER_ORGANIZATION (Organization secret)
+	 - DOCKER_MANAGEMENT_API_REPO_NAME: Name of the dockerhub image for management-api. (ex: management-api-image) (Repository secret)
+	 - DOCKER_PARTICIPANT_API_REPO_NAME: Name of the dockerhub image for participant-api. (ex: participant-api-image) (Repository secret)
+ - **messaging-service**:
+	 - DOCKER_USER (Organization secret)
+	 - DOCKER_PASSWORD (Organization secret)
+	 - DOCKER_ORGANIZATION (Organization secret)
+	 - DOCKER_REPO_MS: Name of the dockerhub image for messaging-service (ex: messaging-service-image) (Repository secret)
+	 - DOCKER_REPO_MSC: Name of the dockerhub image for messaging-scheduler (ex: messaging-scheduler-image) (Repository secret)
+	 - DOCKER_REPO_EC: Name of the dockerhub image for email-client-service (ex: email-client-service-image) (Repository secret)
 
-Once the dockerhub repositories and the secrets have been configured, you will notice that each repository can trigger a build by navigating to the actions tab on github, selecting Docker Image CI and by clicking of the "run workflow" button. An easy method of identifying the different images is by using the version which is identical to the last tagged release in the respective Github repository. You can also choose to override the version being tagged and provide it through a manual input on triggering the workflow.
+Once the Dockerhub repositories and the secrets have been configured, you will notice that each repository can trigger a build by navigating to the actions tab on Github, selecting "Docker Image CI" and by clicking of the "run workflow" button. An easy method of identifying the different images is by using the version which is identical to the last tagged release in the respective Github repository. You can also choose to override the version being tagged and provide it through a manual input on triggering the workflow.
 
-**NOTE** After any change it is important to ensure that a new version of the front-end is running on our deployed server, to do this ensure that you trigger a new build on the Github actions sections of the repo in question. You can create a custom version number before triggering this build. This pushes a new image to dockerhub with the version number you provided. If you don't provide a custom version number, the image will be named after the most recent Github release for this repository.
+**Next**: [Setting up GKE](../installation/3-install-influenzanet-gke.md)

--- a/installation/2-dockerhub-setup.md
+++ b/installation/2-dockerhub-setup.md
@@ -12,7 +12,7 @@ To get started, a dockerhub repository is needed where all the images can reside
 
 ## Configuring docker image builds
 
-Each of the Github repositories comes with a Github Action associated with it. The github action is a file containing code to build a docker image and push this image to the previously created dockerhub repository.
+Each of the GitHub repositories comes with a GitHub Action associated with it. The GitHub action is a file containing code to build a docker image and push this image to the previously created dockerhub repository.
 
 The action file (present in the repository folder .github/workflows) generally contains the following:
 
@@ -55,13 +55,13 @@ By default the build action must be run manually. This behaviour can be modified
 
 ### Docker secrets
 
-Action files make use of **secrets** to store Dockerhub authentication information. They are used by Github actions to login into the Dockerhub repository and push the newly built image.
+Action files make use of **secrets** to store Dockerhub authentication information. They are used by GitHub actions to login into the Dockerhub repository and push the newly built image.
 
-To configure secrets for a Github repository navigate to the settings of the repository  (ex: https://github.com/Influweb-IT/user-management-service/settings), and click on secrets. Here you can create new secrets for your repository.
+To configure secrets for a GitHub repository navigate to the settings of the repository  (ex: https://github.com/Influweb-IT/user-management-service/settings), and click on secrets. Here you can create new secrets for your repository.
 
 **Organization secrets** will be visible to each repository in the organization. **Repository secrets** will be visible only to that particular repository.
 
-The different secrets needed for each of the Github Repositories are listed below:
+The different secrets needed for each of the GitHub Repositories are listed below:
 
  - **participant-webapp**:
 	 - DOCKER_USER : Username for the account on dockerhub (Organization secret)
@@ -88,6 +88,6 @@ The different secrets needed for each of the Github Repositories are listed belo
 	 - DOCKER_REPO_MSC: Name of the dockerhub image for messaging-scheduler (ex: messaging-scheduler-image) (Repository secret)
 	 - DOCKER_REPO_EC: Name of the dockerhub image for email-client-service (ex: email-client-service-image) (Repository secret)
 
-Once the Dockerhub repositories and the secrets have been configured, you will notice that each repository can trigger a build by navigating to the actions tab on Github, selecting "Docker Image CI" and by clicking of the "run workflow" button. An easy method of identifying the different images is by using the version which is identical to the last tagged release in the respective Github repository. You can also choose to override the version being tagged and provide it through a manual input on triggering the workflow.
+Once the Dockerhub repositories and the secrets have been configured, you will notice that each repository can trigger a build by navigating to the actions tab on GitHub, selecting "Docker Image CI" and by clicking of the "run workflow" button. An easy method of identifying the different images is by using the version which is identical to the last tagged release in the respective GitHub repository. You can also choose to override the version being tagged and provide it through a manual input on triggering the workflow.
 
 **Next**: [Setting up GKE](../installation/3-install-influenzanet-gke.md)

--- a/installation/3-install-influenzanet-gke.md
+++ b/installation/3-install-influenzanet-gke.md
@@ -1,4 +1,4 @@
-# Setting up GKE cluster and installing influenzanet
+# Setting up GKE cluster and installing Influenzanet
 
 This topic involves instructions on bringing up a cluster on [GKE](https://cloud.google.com/kubernetes-engine). This requisitions the hardware on which the services making up the Influenzanet platform will run. The second part of this walkthrough will focus on running the scripts needed to get Influenzanet services running on this cluster, using the docker images built in the previous configuration step [Dockerhub Setup](../installation/2-dockerhub-setup.md).
 

--- a/installation/3-install-influenzanet-gke.md
+++ b/installation/3-install-influenzanet-gke.md
@@ -1,13 +1,12 @@
-
 # Setting up GKE cluster and installing influenzanet
 
-This topic involves instructions on bringing up a cluster on GKE. This requisitions the hardware on which influenzanet will run. The second part of this walkthrough focuses on running the scripts needed to get influenzanet running on this cluster.
+This topic involves instructions on bringing up a cluster on [GKE](https://cloud.google.com/kubernetes-engine). This requisitions the hardware on which the services making up the Influenzanet platform will run. The second part of this walkthrough will focus on running the scripts needed to get Influenzanet services running on this cluster, using the docker images built in the previous configuration step [Dockerhub Setup](../installation/2-dockerhub-setup.md).
 
 ## Pre-requisites
 
-Create a google account (influenzanet) and use it to sign into GKE. Set up the required billing contacts and payment details.
+Create a google account and use it to sign into GKE. Set up the required billing contacts and payment details.
 
-Some knowledge of Kubernetes and Kubectl is useful for debugging errors. 
+Some knowledge of Kubernetes and ```kubectl``` is useful for debugging errors. 
 
 ## Creating a cluster
 
@@ -17,25 +16,23 @@ Some knowledge of Kubernetes and Kubectl is useful for debugging errors.
 4. Select the create new cluster option.
 5. Give the cluster a suitable name, select the number of nodes as 2.
 6. Select the node instances to be n1-standard1 (these are sufficient to get the platform started)
-7. Add a persistant SSD of 50 gb
-8. Leave the rest of the configurations as default and click create cluster
+7. Leave the rest of the configurations as default and click create cluster
 
-This should spawn up a new cluster with 2 nodes for us to install influenzanet on.
+This should spawn up a new cluster with 2 nodes for us to install Influenzanet on.
 
 ## Installing Influenzanet
 
-Once on the Kubenetes -> clusters page:
+Once on the Kubernetes -> clusters page:
 1. Click on the 3 dots next to the newly created cluster.
 2. Select connect -> Run in cloud shell.
-3. To install the platform we make use of the git repository [Cluster Management](https://github.com/influenzanet/cluster-management)
-4. Once connected run ``` git clone https://github.com/influenzanet/cluster-management.git ```
-5. Enter into the cloned folder by running ``` cd cluster-management ```
-6. This repository requires you to configure a values.yaml file to provide details about your deployment. Refer to the readme in [Cluster Management](https://github.com/influenzanet/cluster-management)
-7. Refer to the Set up section of the readme in Cluster Management to perform the required configurations before installation.
-8. Once ready, run the script install_start.sh by running ``` sh install_start.sh ```
-
-Note: Sudo permissions may be required to run the install script.
+3. To install the platform we make use of the git repository [cluster management](https://github.com/influenzanet/cluster-management)
+4. Once connected run ```git clone https://github.com/influenzanet/cluster-management.git```
+5. Enter into the cloned folder by running ```cd cluster-management```
+6. This repository requires you to configure a ```values.yaml``` file to provide details about your deployment. Refer to the Readme.md in [cluster management](https://github.com/influenzanet/cluster-management) for detailed instructions
+7. Once ready, run the script install_start.sh by running ```sh install_start.sh```
 
 The install script sets up the load balancer, docker containers for each of the services that are part of the platform, creates a mongoDB instance and also sets up the nginx ingress to route requests to the web app, participant or management api services respectively.
 
-Note: In case scripts fail, navigate to see which deployments are failing. First refer to the [Rollback and Error handling section](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/redeploying-changes/3-rollback-errors.md). If that doesn't help either run the start.sh script or go into cluster-management folder and re-create the deployment that is failing using the kubectl create command. The cheatlist of kubectl commands can be found at [Kubectl Cheat Sheet](https://kubernetes.io/docs/reference/kubectl/cheatsheet/). 
+**Note**: In case the script fails, you'll have to navigate the logs and see which deployments are failing. First refer to the [Rollback and Error handling section](../redeploying-changes/3-rollback-errors.md). If that doesn't help, either run the stop.sh script and then run the start.sh script again or go into cluster-management folder and re-create the deployment that is failing using the ```kubectl create``` command. The cheat sheet for the ```kubectl``` command can be found at [Kubectl Cheat Sheet](https://kubernetes.io/docs/reference/kubectl/cheatsheet/).
+
+**Next**: [MongoDB Setup](../system-configuration/1-mongodb-config.md)

--- a/installation/3-install-influenzanet-gke.md
+++ b/installation/3-install-influenzanet-gke.md
@@ -33,6 +33,6 @@ Once on the Kubernetes -> clusters page:
 
 The install script sets up the load balancer, docker containers for each of the services that are part of the platform, creates a mongoDB instance and also sets up the nginx ingress to route requests to the web app, participant or management api services respectively.
 
-**Note**: In case the script fails, you'll have to navigate the logs and see which deployments are failing. First refer to the [Rollback and Error handling section](../redeploying-changes/3-rollback-errors.md). If that doesn't help, either run the stop.sh script and then run the start.sh script again or go into cluster-management folder and re-create the deployment that is failing using the ```kubectl create``` command. The cheat sheet for the ```kubectl``` command can be found at [Kubectl Cheat Sheet](https://kubernetes.io/docs/reference/kubectl/cheatsheet/).
+**NOTE**: In case the script fails, you'll have to navigate the logs and see which deployments are failing. First refer to the [Rollback and Error handling section](../redeploying-changes/3-rollback-errors.md). If that doesn't help, either run the stop.sh script and then run the start.sh script again or go into cluster-management folder and re-create the deployment that is failing using the ```kubectl create``` command. The cheat sheet for the ```kubectl``` command can be found at [Kubectl Cheat Sheet](https://kubernetes.io/docs/reference/kubectl/cheatsheet/).
 
 **Next**: [MongoDB Setup](../system-configuration/1-mongodb-config.md)

--- a/maintenance/1-checklist.md
+++ b/maintenance/1-checklist.md
@@ -5,8 +5,8 @@ The following represents the list of activities to be perfomed over the course o
 
 | Activity      | Priority  | Frequency |
 | -------------- | :----------------:| ----------------:|
-| Inspect support emails on influenzanet@uhasselt.be | High | As new emails come in / twice a week |
-| Check mailgun logs | High | Everyday during initial release, 2-3 times a week after |
+| Inspect support emails on the support account | High | As new emails come in / twice a week |
+| Check mailgun logs if used as SMTP | High | Everyday during initial release, 2-3 times a week after |
 | Check GKE resource usage [Cluster & per service] | Medium | Everyday during initial release, 2-3 times a week after |
 | Increase or decrease resource allocation GKE | Medium | As needed |
 | Periodially create data back-ups of the mongoDB | High | Monthly |
@@ -16,3 +16,5 @@ The following represents the list of activities to be perfomed over the course o
 | Communicate scheduled down-time when notified by GKE | Monthly | Monthly |
 | Merge new versions from Upstream on Github | Low | Monthly |
 | Re-deploy new versions if approved | Low | Monthly or more |
+
+**Next**: [Issue Resolution](../maintenance/2-issue-resolution.md)

--- a/maintenance/1-checklist.md
+++ b/maintenance/1-checklist.md
@@ -14,7 +14,7 @@ The following represents the list of activities to be perfomed over the course o
 | Routinely download participant responses | Medium | Weekly |
 | Look for potential node upgrades by GKE | Low | Monthly |
 | Communicate scheduled down-time when notified by GKE | Monthly | Monthly |
-| Merge new versions from Upstream on Github | Low | Monthly |
+| Merge new versions from Upstream on GitHub | Low | Monthly |
 | Re-deploy new versions if approved | Low | Monthly or more |
 
 **Next**: [Issue Resolution](../maintenance/2-issue-resolution.md)

--- a/maintenance/1-checklist.md
+++ b/maintenance/1-checklist.md
@@ -1,7 +1,7 @@
 # Maintenance Activity Checklist
 
 
-The following represents the list of activities to be perfomed over the course of the lifecycle of influenzanet:
+The following represents the list of activities to be perfomed over the course of the lifecycle of Influenzanet:
 
 | Activity      | Priority  | Frequency |
 | -------------- | :----------------:| ----------------:|

--- a/maintenance/2-issue-resolution.md
+++ b/maintenance/2-issue-resolution.md
@@ -62,7 +62,7 @@ Once an immediate response is drafted by the support team, the system admin take
             
             - `begium_studyDB` -> contains collections for each study in the platform and it’s participants, surveys and surveyResponses.
 
-        - To use a database enter ```use db-name```. For ex: ```use belgium_users```
+        - To use a database enter ```use db-name```. For eg: ```use belgium_users```
         
         - To find user count run ```db.users.count()``` after selecting the belgium_users database for use.
         

--- a/maintenance/2-issue-resolution.md
+++ b/maintenance/2-issue-resolution.md
@@ -42,7 +42,7 @@ Once an immediate response is drafted by the support team, the system admin take
     
     - Or if there is a different issue that requires mailgun support, immediate create a support request with Mailgun.
 
-2. To investigate GKE, log in with influenzanet admin account into google cloud console.
+2. To investigate GKE, log in with Influenzanet admin account into google cloud console.
 
     - Look for Kubernetes in the menu on the top left corner and click on clusters
     

--- a/maintenance/2-issue-resolution.md
+++ b/maintenance/2-issue-resolution.md
@@ -5,55 +5,96 @@ General guideline for handling bug reports or errors discovered in the system
 ## Roles
 
 1. Support team: All personnel handling the supprot email addresses linked with the platform.
-2. System Admin: Accounts with access to Mailgun logs as well as GKE environment.
+
+2. System Admin: Accounts with access to Mailgun logs (if used) as well as GKE environment.
 
 ## Types of Issues: 
 
-1. Errors reported via email to influenzanet@uhasselt.be
+1. Errors reported via email to the support email
+
 2. Errors detected through GKE logs, and Mailgun logs/analytics.
 
 
 ## Resolution Procedure:
 
-In case the error was reported via email, first follow the procedure laid out below: [Responsibilty - Support team]
-1. Inform Infectie Radar admin of the error reported by email.
+In case the error was reported via email, first follow the procedure laid out below: 
+
+[Responsibilty - Support team]
+
+1. Inform your platform administrator of the error reported by email.
+
 2. Write back to inform that this error is being looked into. - Perhaps prepare a template auto response for this 
 
 
 Once an immediate response is drafted by the support team, the system admin takes the following steps: 
-1. First look at Mailgun logs to assess the problem.
-    - Log into mailgun, go to Sending -> Logs (select survey.influenzanet.be)
+
+1. First look at Mailgun logs (if used) to assess the problem.
+
+    - Log into mailgun, go to Sending -> Logs
+    
     - Filter the logs according to the email id of the user facing the problem (if support request received)
+    
     - Goal is to find which emails are failing or have been delivered too late.
+    
     - Some example causes - > Registration email delivered too late, Login code delivered too late, or Login code delivery failed etc.
+    
     - You can attempt to resend failed emails here, or also can view the content of the email to further help out the participant. (You can extract the code or the registration link directly and send to the participant)
+    
     - Or if there is a different issue that requires mailgun support, immediate create a support request with Mailgun.
+
 2. To investigate GKE, log in with influenzanet admin account into google cloud console.
+
     - Look for Kubernetes in the menu on the top left corner and click on clusters
+    
     - Workloads gives you a description of the services that are currently running -> How many pods, which image version is being used, current limits on resources=> how much ram or cpu can a pod take (upper limit), etc.
+    
     - To investigate mongodb
-        - Connect to mongodb by following the steps mentioned in [mongo-connect-configure](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/system-configuration/1-mongodb-config.md)
+        
+        - Connect to mongodb by following the steps mentioned in [mongo-connect-configure](../system-configuration/1-mongodb-config.md)
+        
         - Now you should be inside the mongo shell
+        
         - List the databases by running ```show dbs```
+        
         - The following databases are of importance (we use belgium as an example instance here):
-            - Belgium_users - > contains collections of users in the system
-            - begium_studyDB -> contains collections for each study in the platform and it’s participants, surveys and surveyResponses.
+        
+            - `belgium_users` - > contains collections of users in the system
+            
+            - `begium_studyDB` -> contains collections for each study in the platform and it’s participants, surveys and surveyResponses.
+
         - To use a database enter ```use db-name```. For ex: ```use belgium_users```
+        
         - To find user count run ```db.users.count()``` after selecting the belgium_users database for use.
+        
         - Once a database is selected, you can see what collections are present by running: ```show collections```
+        
         - To find a user run: ```db.users.find({“account.accountID”: “<EMAIL-ID>”})```. Here “user” is a collection present within belgium_users. This should allow you find potential problems in that user’s account.
+        
         - Some examples are: 
+        
             - If accountConfirmedAt field is at Number(0) then the account is not confirmed yet and needs to be confirmed.
+            
             - If account is confirmed, user may have initiated a login token that is now expired. To check this look for the field “expiresAt” within “verificationCode” to determine if the token has expired.
+            
             - To turn off 2-FA run: db.users.updateOne({"account.accountID": "<email-id>"}, {$set: {"authType": ""}})
             - To reset the 2FA run: db.users.updateOne({"account.accountID": "<email-id>"}, {$set: {"authType": "2FA"}})
+        
         - To find other information wrt to studies run : ```use belgium_studyDB``` (optional show collections)
+        
         - To find participants in the influenzanet-be study, run: ```db['influenzanet-be_participants'].count()```
+        
         - To find total responses collected so far, run: ```db['influenzanet-be_surveyResponses'].count()```
+        
         - Once done exit the mongo shell by typing: exit
+        
         - Type exit once again to return to the GKE terminal
+    
     - Investigate and check if resource limits are causing issues with any of the services.
+    
     - Look for log entries showing failures in services like participant-api, user-management or study-management.
+    
     - Look for errors showing up in the logs for mongo.
+
 3. If error cause could not be determined or if errors requires more detailed code fixes, contact Coneno for support requests and bug fixes.
 
+**Next**: [Scaling Resources](../maintenance/3-resource-scaling.md)

--- a/maintenance/3-resource-scaling.md
+++ b/maintenance/3-resource-scaling.md
@@ -32,7 +32,7 @@ There may be some cases where one workloads consumes more resources than it need
 
 - Edit the yaml file and add the following section within the container tag:
 
-    ```
+    ```yaml
     resources:
         requests:
             cpu: 30m

--- a/maintenance/3-resource-scaling.md
+++ b/maintenance/3-resource-scaling.md
@@ -7,13 +7,21 @@ This section deals with some scenarios where you may need to adjust resources av
 In the default deployment, there are 2 nodes (or machines) present in the Google Kubernetes Cluster. The cluster also contains configurations to automatically scale up or down hardware. This can be adjusted by performing the following steps:
 
 - Log into GKE, and navigate to the clusters page.
+
 - Click on the cluster being used, to open up the details of the cluster.
+
 - Select the nodes tab to display the pools of nodes being used.
+
 - Select the default-pool and click edit.
+
     - Here you can reconfigure what the current number of nodes in the system are.
+    
     - You can set a minimum and maximum number of nodes that can be requested automatically based on demand.
+    
     - Keep in mind, that new nodes are going to be of the same type of machine (ex: n1-standard-1) as previously picked while creating the cluster.
+    
     - If you want to add a different machine type, add a new node-pool to list of machines.
+    
     - While scaling down resources, be aware that default system services run by Google (such as Kubernetes system workloads) also require some amount of CPU and Memory.
 
 ## Limiting resources consumed by a workload
@@ -21,7 +29,9 @@ In the default deployment, there are 2 nodes (or machines) present in the Google
 There may be some cases where one workloads consumes more resources than it needs to function. It may be advisable to set resource limits of each workload. This can be done by:
 
 - Navigating to workloads and selecting the deployment to be limited (for ex: Mongo)
+
 - Edit the yaml file and add the following section within the container tag:
+
     ```
     resources:
         requests:
@@ -31,6 +41,7 @@ There may be some cases where one workloads consumes more resources than it need
             cpu: 150m
             memory: 300Mi
     ```
+
 - You can reconfigure the values here to suit your needs.
 
 ## Scaling up replicas of a workload
@@ -40,9 +51,13 @@ This involves the creation of multiple replica's of the same pod in a deployment
 Advantages of doing this is that you have improved availabilty to end users and better schedulability of a pod within the nodes requisitioned for the cluster.
 
 To scale up or down replica sets:
+
 - Navigate to the workloads page and select the workload you wish to scale.
+
 - Select the actions dropdown and select scale.
+
 - THis queries the number of instances you wish to create.
+
 - Enter a suitable number, which can be more (up-scale) or less (down-scale) than what the deployment previously ran on.
 
-NOTE: The system is designed to handle multiple instances of all workloads without causing data inconsistencies. The only bottleneck here is the mongodb which always has only a single instance. [Due to the GKE limitations on Many to One write capabilities on persistant disk]
+**NOTE**: The system is designed to handle multiple instances of all workloads without causing data inconsistencies. The only bottleneck here is the mongodb which always has only a single instance. [Due to the GKE limitations on Many to One write capabilities on persistent disk]

--- a/maintenance/3-resource-scaling.md
+++ b/maintenance/3-resource-scaling.md
@@ -18,7 +18,7 @@ In the default deployment, there are 2 nodes (or machines) present in the Google
     
     - You can set a minimum and maximum number of nodes that can be requested automatically based on demand.
     
-    - Keep in mind, that new nodes are going to be of the same type of machine (ex: n1-standard-1) as previously picked while creating the cluster.
+    - Keep in mind, that new nodes are going to be of the same type of machine (eg: n1-standard-1) as previously picked while creating the cluster.
     
     - If you want to add a different machine type, add a new node-pool to list of machines.
     
@@ -28,7 +28,7 @@ In the default deployment, there are 2 nodes (or machines) present in the Google
 
 There may be some cases where one workloads consumes more resources than it needs to function. It may be advisable to set resource limits of each workload. This can be done by:
 
-- Navigating to workloads and selecting the deployment to be limited (for ex: Mongo)
+- Navigating to workloads and selecting the deployment to be limited (for eg: Mongo)
 
 - Edit the yaml file and add the following section within the container tag:
 

--- a/redeploying-changes/1-change-types.md
+++ b/redeploying-changes/1-change-types.md
@@ -16,6 +16,6 @@ These are the scenarios where a re-deployment is not advised or is simply not ne
 
 2. Changes like new emails, surveys or studies do not need a re-deployment.
 
-3. Configurations changes like changing ReCAPTCHA keys, mongo credentials, changing period between new weekly surveys, and changing user sign up limits do not need a re-deployment. General rule of thumb here is to refer to the deployment files in [Cluster Management](https://github.com/influenzanet/cluster-management). Any env variable defined in these files can be changed on the fly, without a re-deploying a new version.
+3. Configurations changes like changing ReCAPTCHA keys, mongo credentials, changing period between new weekly surveys, and changing user sign up limits do not need a re-deployment. General rule of thumb here is to refer to the deployment files in [cluster management](https://github.com/influenzanet/cluster-management). Any env variable defined in these files can be changed on the fly, without a re-deploying a new version.
 
 **Next**: [Redeploying Changes](../redeploying-changes/2-build-and-redeploy.md)

--- a/redeploying-changes/1-change-types.md
+++ b/redeploying-changes/1-change-types.md
@@ -3,11 +3,19 @@
 Before proceeding, we cover the different types of changes where a simple, straightforward re-deployment is advisable: 
 
 1. Markdown changes: Changing the text on any of the web-pages.
+
 2. Image/Video changes: Change images, or video links in the influenzanet web UI.
+
 3. Bug fixes: Tested changes to any of the 6 repositories or 9 images that form a part of influenzanet.
+
 4. New features: Tested feature addition/changes to any components of the influenzanet platform.
 
 These are the scenarios where a re-deployment is not advised or is simply not needed:
+
 1. Untested bug-fixes/features: Re-deployment goes live immediately, so this should be avoided.
+
 2. Changes like new emails, surveys or studies do not need a re-deployment.
+
 3. Configurations changes like changing ReCAPTCHA keys, mongo credentials, changing period between new weekly surveys, and changing user sign up limits do not need a re-deployment. General rule of thumb here is to refer to the deployment files in [Cluster Management](https://github.com/influenzanet/cluster-management). Any env variable defined in these files can be changed on the fly, without a re-deploying a new version.
+
+**Next**: [Redeploying Changes](../redeploying-changes/2-build-and-redeploy.md)

--- a/redeploying-changes/1-change-types.md
+++ b/redeploying-changes/1-change-types.md
@@ -4,11 +4,11 @@ Before proceeding, we cover the different types of changes where a simple, strai
 
 1. Markdown changes: Changing the text on any of the web-pages.
 
-2. Image/Video changes: Change images, or video links in the influenzanet web UI.
+2. Image/Video changes: Change images, or video links in the Influenzanet web UI.
 
-3. Bug fixes: Tested changes to any of the 6 repositories or 9 images that form a part of influenzanet.
+3. Bug fixes: Tested changes to any of the 6 repositories or 9 images that form a part of Influenzanet.
 
-4. New features: Tested feature addition/changes to any components of the influenzanet platform.
+4. New features: Tested feature addition/changes to any components of the Influenzanet platform.
 
 These are the scenarios where a re-deployment is not advised or is simply not needed:
 

--- a/redeploying-changes/2-build-and-redeploy.md
+++ b/redeploying-changes/2-build-and-redeploy.md
@@ -2,7 +2,7 @@
 
 ## Building new images after a code change
 
-Every repository that forms the core of the Influenzanet platform contains a github actions file associated with it. This action file is responsible for allowing us to build a new image out of the repository after a code change. The action also pushes the newly built image into the linked docker repository. To trigger this action perform the following:
+Every repository that forms the core of the Influenzanet platform contains a GitHub actions file associated with it. This action file is responsible for allowing us to build a new image out of the repository after a code change. The action also pushes the newly built image into the linked docker repository. To trigger this action perform the following:
 
 1. Navigate to the repository with a change (for ex: The participant-webapp repository after a change in the results page).
 
@@ -36,7 +36,7 @@ on: [push, pull_request]
 
 **NOTE**: Only the repositories where a change has occurred needs to be re-built. However in the case of API-gateway and messaging-service, these are built into 2 and 3 new images respectively since these are sub-divided as discussed in [Dockerhub Setup](../installation/2-dockerhub-setup.md).
 
-Since the build and deploy are then automatically handled by Github and Dockerhub, the only remaining task is to link these newly created images to the installed Influenzanet platform running on Google Kubernetes Engine.
+Since the build and deploy are then automatically handled by GitHub and Dockerhub, the only remaining task is to link these newly created images to the installed Influenzanet platform running on Google Kubernetes Engine.
 
 ## Updating new image versions in GKE
 
@@ -44,9 +44,9 @@ Running the installation scripts in [gke-influenzanet-installation](https://gith
 
 To update the deployment and use the newly built image, we can take an example of a change that occurs in the participant-webapp:
 
-1. Once a code change is made, wait for Github to complete building and deploying the image to Dockerhub.
+1. Once a code change is made, wait for GitHub to complete building and deploying the image to Dockerhub.
 
-2. You can get the version number of this new build by signing into dockerhub, click on the repository (here the participant-webapp  repository), look for a recently uploaded image. Generally version numbers are marked according to the latest tags of their corresponding Github repositories.
+2. You can get the version number of this new build by signing into dockerhub, click on the repository (here the participant-webapp  repository), look for a recently uploaded image. Generally version numbers are marked according to the latest tags of their corresponding GitHub repositories.
 
 3. Next sign into GKE, navigate to Kubernetes Engine, and click on workloads.
 

--- a/redeploying-changes/2-build-and-redeploy.md
+++ b/redeploying-changes/2-build-and-redeploy.md
@@ -20,7 +20,7 @@ You can optionally also choose to automate this process for every new commit tha
 
 Replace this section:
 
-```
+```yaml
 on:
 workflow_dispatch:
 inputs:
@@ -30,7 +30,7 @@ description: 'Docker Tag override: [leave empty if not needed]'
 
 with
 
-```
+```yaml
 on: [push, pull_request]
 ```
 
@@ -52,7 +52,7 @@ To update the deployment and use the newly built image, we can take an example o
 
 4. This contains a list of workloads (representing each deployment). Click on web-client in our example. Next click on edit. This should bring up a yaml file that describes the running version of web-client on GKE. The file should look like:
 
-```
+```yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/redeploying-changes/2-build-and-redeploy.md
+++ b/redeploying-changes/2-build-and-redeploy.md
@@ -36,7 +36,7 @@ on: [push, pull_request]
 
 **NOTE**: Only the repositories where a change has occurred needs to be re-built. However in the case of API-gateway and messaging-service, these are built into 2 and 3 new images respectively since these are sub-divided as discussed in [Dockerhub Setup](../installation/2-dockerhub-setup.md).
 
-Since the build and deploy are then automatically handled by Github and Dockerhub, the only remaining task is to link these newly created images to the installed influenzanet platform running on Google Kubernetes Engine.
+Since the build and deploy are then automatically handled by Github and Dockerhub, the only remaining task is to link these newly created images to the installed Influenzanet platform running on Google Kubernetes Engine.
 
 ## Updating new image versions in GKE
 

--- a/redeploying-changes/2-build-and-redeploy.md
+++ b/redeploying-changes/2-build-and-redeploy.md
@@ -4,7 +4,7 @@
 
 Every repository that forms the core of the Influenzanet platform contains a GitHub actions file associated with it. This action file is responsible for allowing us to build a new image out of the repository after a code change. The action also pushes the newly built image into the linked docker repository. To trigger this action perform the following:
 
-1. Navigate to the repository with a change (for ex: The participant-webapp repository after a change in the results page).
+1. Navigate to the repository with a change (for eg: The participant-webapp repository after a change in the results page).
 
 2. Click on the actions tab
 

--- a/redeploying-changes/2-build-and-redeploy.md
+++ b/redeploying-changes/2-build-and-redeploy.md
@@ -3,112 +3,82 @@
 ## Building new images after a code change
 
 Every repository that forms the core of the Influenzanet platform contains a github actions file associated with it. This action file is responsible for allowing us to build a new image out of the repository after a code change. The action also pushes the newly built image into the linked docker repository. To trigger this action perform the following:
+
 1. Navigate to the repository with a change (for ex: The participant-webapp repository after a change in the results page).
-2. CLick on the actions tab
+
+2. Click on the actions tab
+
 3. Select docker image CI under the workflow options
-4. CLick on the run workflow button. 
+
+4. Click on the run workflow button. 
+
 5. In the input field you can enter a version number for the build, or leave it blank to reuse the version number from the latest release.
+
 6. Wait for the action to trigger and run to completion. This will push a built image to dockerhub with the input version number.
 
-**NOTE**: You can optionally also choose to automate this process for every new commit that is pushed into the repository. To do so, navigate to the .github/workflows folder and edit the docker-image.yml file.
-          Replace this section:
-          ```
-          on:
-            workflow_dispatch:
-              inputs:
-                tags:
-                  description: 'Docker Tag override: [leave empty if not needed]'
-          ```
-          with
-          ```
-          on: [push, pull_request]
-          ```
+You can optionally also choose to automate this process for every new commit that is pushed into the repository. To do so, navigate to the .github/workflows folder and edit the docker-image.yml file.
 
-**NOTE**: Only the repositories where a change has occurred needs to be re-built. However in the case of API-gateway and messaging-service, these are built into 2 and 3 new images respectively since these are sub-divided as discussed in [dockerhub-setup](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/installation/2-dockerhub-setup.md).
+Replace this section:
+
+```
+on:
+workflow_dispatch:
+inputs:
+tags:
+description: 'Docker Tag override: [leave empty if not needed]'
+```
+
+with
+
+```
+on: [push, pull_request]
+```
+
+**NOTE**: Only the repositories where a change has occurred needs to be re-built. However in the case of API-gateway and messaging-service, these are built into 2 and 3 new images respectively since these are sub-divided as discussed in [Dockerhub Setup](../installation/2-dockerhub-setup.md).
 
 Since the build and deploy are then automatically handled by Github and Dockerhub, the only remaining task is to link these newly created images to the installed influenzanet platform running on Google Kubernetes Engine.
 
 ## Updating new image versions in GKE
 
-Running the installation scripts in [gke-influenzanet-installation](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/installation/3-install-influenzanet-gke.md) creates a deployment for each of the services of influenzanet. These services are linked to a built image residing in Dockerhub.
+Running the installation scripts in [gke-influenzanet-installation](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/installation/3-install-influenzanet-gke.md) creates a deployment for each of the services of Influenzanet. These services are linked to a built image residing in Dockerhub.
 
-To update this to the newly uploaded image, we can take an example of a change that occurs in the participant-webapp:
+To update the deployment and use the newly built image, we can take an example of a change that occurs in the participant-webapp:
+
 1. Once a code change is made, wait for Github to complete building and deploying the image to Dockerhub.
+
 2. You can get the version number of this new build by signing into dockerhub, click on the repository (here the participant-webapp  repository), look for a recently uploaded image. Generally version numbers are marked according to the latest tags of their corresponding Github repositories.
+
 3. Next sign into GKE, navigate to Kubernetes Engine, and click on workloads.
+
 4. This contains a list of workloads (representing each deployment). Click on web-client in our example. Next click on edit. This should bring up a yaml file that describes the running version of web-client on GKE. The file should look like:
+
 ```
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: "2021-03-12T14:33:45Z"
-  generation: 42
-  labels:
-    app: web-client
-  name: web-client
-  namespace: belgium
-  resourceVersion: "47793022"
-  selfLink: /apis/apps/v1/namespaces/belgium/deployments/web-client
-  uid: 94f3732f-38bc-4026-9724-bb2f0e5f53b9
+  [...]
 spec:
-  progressDeadlineSeconds: 600
-  replicas: 1
-  revisionHistoryLimit: 10
-  selector:
-    matchLabels:
-      app: web-client
-  strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
+  [...]
   template:
     metadata:
-      annotations:
-        linkerd.io/inject: disabled
-      creationTimestamp: null
-      labels:
-        app: web-client
+    [...]
     spec:
       containers:
       - image: influenzanet/participant-webapp:v0.0.1
         imagePullPolicy: Always
         name: web-client
-        ports:
-        - containerPort: 3100
-          protocol: TCP
-        resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-      dnsPolicy: ClusterFirst
-      restartPolicy: Always
-      schedulerName: default-scheduler
-      securityContext: {}
-      terminationGracePeriodSeconds: 30
 status:
-  availableReplicas: 1
-  conditions:
-  - lastTransitionTime: "2021-03-28T10:25:37Z"
-    lastUpdateTime: "2021-03-28T10:25:37Z"
-    message: Deployment has minimum availability.
-    reason: MinimumReplicasAvailable
-    status: "True"
-    type: Available
-  - lastTransitionTime: "2021-03-12T14:33:45Z"
-    lastUpdateTime: "2021-04-06T16:11:55Z"
-    message: ReplicaSet "web-client-75db57ddd6" has successfully progressed.
-    reason: NewReplicaSetAvailable
-    status: "True"
-    type: Progressing
-  observedGeneration: 42
-  readyReplicas: 1
-  replicas: 1
-  updatedReplicas: 1
+  [...]
 ```
-5. The only important line to edit here is the following ```- image: influenzanet/participant-webapp:v0.0.1```. This line describes the currently used image version from Dockerhub. Update this version to the newly built image version. (just replace the v0.0.1).
+
+5. The only important line to edit here is the following ```- image: influenzanet/participant-webapp:v0.0.1```. This line describes the currently used image version from Dockerhub. Update this version to reflect the newly built image version. (just replace the v0.0.1).
+
 6. Once complete, click save.
+
 7. This notifies Kubernetes to first try bringing up a new version of participant-webapp, and if successful then bring down the older version. The end-user doesn't notice the difference as long as the new version works as expected.
 
 This process remains the same for changes to any of the other images (management-api, participant-api, study-service, etc). The image version needs to be changed in the relevant workload.
 
-NOTE: There is no need to re-edit files of every workload, just the ones where a new image is created.
+**NOTE**: There is no need to re-edit the configuration files of every workload, just the ones using the newly created image.
+
+**Next**: [Rollback Errors](../redeploying-changes/3-rollback-errors.md)

--- a/redeploying-changes/3-rollback-errors.md
+++ b/redeploying-changes/3-rollback-errors.md
@@ -62,7 +62,7 @@ There are two versions of this available:
     
     1.4. Connect to the cluster and re-run the ```sh install_start.sh``` script.
     
-    1.5. This will re-create not just the influenzanet workloads, but also the certificate manager, nginx ingress controller and recreates all the persisitant volume claims.
+    1.5. This will re-create not just the Influenzanet workloads, but also the certificate manager, nginx ingress controller and recreates all the persisitant volume claims.
     
     1.6. Navigate to storage and restore the backed up version to retain the database entries.
     

--- a/redeploying-changes/3-rollback-errors.md
+++ b/redeploying-changes/3-rollback-errors.md
@@ -1,33 +1,35 @@
 # Rollback and error handling
 
-
-## Scenario 1 - On Yaml edit, new version fails to deploy.
+## Scenario 1 - On redeploy, the new image fails to start
 
 In case the workload fails to bring up a new instance of the new image. There are a couple of steps to be followed:
 
 1. The older version is still in use, so end users still see the older version. This gives us some time to explore what the issue is.
+
 2. In general navigate to the workload, and look for errors. Also look for errors in the logs section.
+
 3. After navigating to workloads, scroll down to see the managed pods, click the pod that is failing (newly created one for the new image version). You may find additional details here, or in the logs sections of this pod.
+
 4. Generally errors occur due to version mismatch (no such image exists in Dockerhub), invalid pull rights (this can happen if the dockerhub repo is configured as private instead of public). Additionally if the machines in the cluster do not have sufficient memory or CPU, this can also lead to a failure in creating the new pod.
+
 5. Try resolving these issues, and wait for the errors to be resolved. 
+
 6. In case the errors cannot be resolved, edit the yaml to revert to the older version of the image. Delete the failing pod and wait for the error to be resolved.
+
 7. Delete both pods and wait for the older version to be re-created if the above does not work.
-8. In the rare case that all of the above fails, there is a method to re-create the specific deployment that is failing:
-    8.1. To do so go back to workloads, delete the deployment that is failing (for example: web-client).
-    8.2. Navigate to clusters, click on the 3 dots and then connect.
-    8.3. Once you're in the terminal cd to the cluster-management directory. (this should have been created previously in the section [gke-influenzanet-installation](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/installation/3-install-influenzanet-gke.md)). If not present, re-clone the repo and set the branch to correct country.
-    8.4. Navigate to the deployments folder in this repository.
-    8.5. You can re-create the specific deployment (in our case the web-client) by running the command ``` kubectl create -f web-client-deployment.yaml  ```
-    8.6. This will create a fresh deployment of the participant-webapp. This process can be repeated for any of the other deployments as well, just by changing the file name in 8.5. (Use this only if all above fails)
 
 ## Scenario 2: New version successfully deployed but has errors in runtime.
 
 This is a scenario where errors that haven't been found during testing have shown up after a new version has been successfully deployed. In this case the resolution to be followed is as follows:
 
 1. The older version is no longer running, so all participants are now exposed to the new image with the errors and bugs.
+
 2. To revert to the older image, navigate to Workloads section of Kubernetes in GKE. 
+
 3. Select the workload whose image version needs to be reverted.
+
 4. Click edit and replace the image version to the older version and click save.
+
 5. This should successfully bring up the older bug-free version.
 
 ## Scenario 3: Multiple fail-overs and configurations errors
@@ -37,17 +39,31 @@ This is the worst case scenario, where a fresh deployment of all services is nee
 There are two versions of this available: 
 
 1. Re-create only the influenzanet-services:
-    1.1. Copy the contents of the persisitant SSD (mongo) and back them up else where. Navigate to storage in Kubernetes on GKE to perform this task.
+
+    1.1. Copy the contents of the PersistentVolume (mongo) and back them up else where. Navigate to storage in Kubernetes on GKE to perform this task.
+    
     1.2. Once the data is backed up, connect to the cluster and open the terminal.
-    1.3. cd into the cluster-management folder, and run the script ```sh  stop.sh ```
+    
+    1.3. cd into the cluster-management folder, and run the script ```sh  stop.sh```
+    
     1.4. This removes all the services, secrets and configurations in the system.
-    1.5. Re-create the configurations (if needed) and run ``` sh start.sh ``` to reinstall the workloads.
+    
+    1.5. Re-create the configurations (if needed) and run ```sh start.sh ``` to reinstall the workloads.
+    
     1.6. This process maintains the DB as before, so the data back up is only a precautionary measure
 
 2. Completely re-install the system:
-    1.1. Copy the contents of the persisitant SSD (mongo) and back them up else where. Navigate to storage in Kubernetes on GKE to perform this task.
+
+    1.1. Copy the contents of the PersistentVolume (mongo) and back them up else where if you didn't already. Navigate to storage in Kubernetes on GKE to perform this task.
+    
     1.2. Navigate to clusters, and delete the cluster present.
+    
     1.3. Re-do the process of requisitioning a cluster.
+    
     1.4. Connect to the cluster and re-run the ```sh install_start.sh``` script.
+    
     1.5. This will re-create not just the influenzanet workloads, but also the certificate manager, nginx ingress controller and recreates all the persisitant volume claims.
+    
     1.6. Navigate to storage and restore the backed up version to retain the database entries.
+    
+**Next**: [Maintenance Activity checklist](../maintenance/1-checklist.md)

--- a/system-configuration/1-mongodb-config.md
+++ b/system-configuration/1-mongodb-config.md
@@ -37,13 +37,13 @@ Using the web application front-end, create a new user (who is to be promoted ad
 1. Switch to the user DB by running ```use belgium_users```
 2. Find the user created by the web-app by running:
 
-    ```
+    ```javascript
     admin = db.users.findOne({"account.accountID": "<email-id>"})
     ```
     
 3. Modify and update the user:
    
-   ```
+   ```javascript
    admin.account.accountConfirmedAt = NumberLong((new Date()).getTime());
    admin.roles = ["PARTICIPANT", "ADMIN"];
    admin.account.authType= "";

--- a/system-configuration/1-mongodb-config.md
+++ b/system-configuration/1-mongodb-config.md
@@ -2,34 +2,56 @@
 
 ## Pre-requisites
 
-Ensure that mongo is running and installed through the installation script mentioned in [gke-influenzanet-installation](https://github.com/influenzanet/influenzanet-setup-guide/blob/master/installation/3-install-influenzanet-gke.md). 
+Ensure that mongo is running and installed through the installation script mentioned in [gke-influenzanet-installation](../installation/3-install-influenzanet-gke.md). 
 
-Note: This also assumes that you have created the required entries for Mongo usernames and passwords in the guide in [Cluster Management](https://github.com/influenzanetBE/cluster-management)
+This also assumes that you have created the required entries for Mongo usernames and passwords described in [cluster management](https://github.com/influenzanet/cluster-management)
 
 ## Connecting to Mongo
 
 1. Connect to the Kubernetes cluster by logging in to the google cloud platform.
-2. Once connected, we need to find the pod id where mongo is running. We use "Belgium" as an example instance, please replace it with your namespace. Do this by running ```kubectl get pods -n belgium```
+
+2. Once connected, we need to find the pod id where mongo is running. We use ```belgium``` namespace as an example, please replace it with your namespace. Do this by running ```kubectl get pods -n belgium```
+
 3. This returns a list of active pods, copy the id of the one with mongo in its name. Usually something similar to ```mongo-77cf57567c-c8nkp```
-4. Use this enter into the mongo pod by running the command ``` kubectl exec -it <copied-mongo-id> --namespace=belgium -c mongo bash ```
-5. This should bring up a shell where you need to enter ``` mongo -u <username> -p <password> ```
+
+4. Use this enter into the mongo pod by running the command ```kubectl exec -it <copied-mongo-id> --namespace=belgium -c mongo bash```
+
+5. This should bring up a shell where you need to enter ```mongo -u <username> -p <password>```
+
 6. That should bring you into the mongo shell where you can look up databases, collections, entries, etc.
 
-Note: Only the system administrator has access to this.
+Note: Only administrators of the cluster have access to this.
 
 ## Initial Mongo configurations
 
-With the web-app running create a new user (who is to be admin) by registering at the User Interface.
-
 After connecting to MongoDB for the first time after installation a few entries need to be put in manually. These are as follows:
 
-1. Enter ``` show dbs``` to list all the databases in the system.
-2. Select the global-Infos db by running ``` use global-infos ```.
-3. Check the collections within global-infos by running ``` show collections ```
-4. If the collections instances is not present, create it by running ``` db.createCollection('instances') ```.
-5. Insert one row with your instance name (belgium in this case) by running ``` db.instances.insert({"instanceID": "belgium"})```
-6. Switch to the user DB by running ``` use belgium_users ```
-7. Find and update the email used to initially create a new user at the web-app by running ```db.users.updateOne({"account.accountID": "<email-id>"}, {$set : {"roles": ["PARTICIPANT", "ADMIN"]} }) ```
-8. this gives admin rights to the user in question.
+1. Enter ```show dbs``` to list all the databases in the system.
+2. Select the global-Infos db by running ```use global-infos```.
+3. Check the collections within global-infos by running ```show collections```
+4. If the collections instances is not present, create it by running ```db.createCollection('instances')```.
+5. Insert one row with your instance name (belgium in this case) by running ```db.instances.insert({"instanceID": "belgium"})```
 
-Once this is complete, your mongo is ready for use.
+Using the web application front-end, create a new user (who is to be promoted admin) by following the registration process into the website until you are asked to verify your email. Then switch back to the mongo shell and:
+
+1. Switch to the user DB by running ```use belgium_users```
+2. Find the user created by the web-app by running:
+
+    ```
+    admin = db.users.findOne({"account.accountID": "<email-id>"})
+    ```
+    
+3. Modify and update the user:
+   
+   ```
+   admin.account.accountConfirmedAt = NumberLong((new Date()).getTime());
+   admin.roles = ["PARTICIPANT", "ADMIN"];
+   admin.account.authType= "";
+   db.user.replaceOne(({"account.accountID": "<email-id>"}, admin);
+   ```
+
+This verifies and gives admin rights to the user in question, also disabling two factor authentication.
+
+Once this is complete, your mongo is ready to use and you can proceed to the system configuration using the admin user credentials.
+
+**Next**: [Creating a Study](../system-configuration/2-create-study-surveys.md)

--- a/system-configuration/1-mongodb-config.md
+++ b/system-configuration/1-mongodb-config.md
@@ -20,7 +20,7 @@ This also assumes that you have created the required entries for Mongo usernames
 
 6. That should bring you into the mongo shell where you can look up databases, collections, entries, etc.
 
-Note: Only administrators of the cluster have access to this.
+**NOTE**: Only administrators of the cluster have access to this.
 
 ## Initial Mongo configurations
 

--- a/system-configuration/2-create-study-surveys.md
+++ b/system-configuration/2-create-study-surveys.md
@@ -1,6 +1,6 @@
 # Creating studies and surveys
 
-influenzanet is firstly a survey platform. This section explains the steps involved in creating a new study in the system and then adding surveys to the study.
+Influenzanet is firstly a survey platform. This section explains the steps involved in creating a new study in the system and then adding surveys to the study.
 
 ## Pre-requisites
 
@@ -9,10 +9,18 @@ To create, and upload studies and surveys you need to configure two repositories
 1. [Study-Manager-App](https://github.com/influenzanet/study-manager-app): Clone the repository in the link. Install the required dependencies by running ``` yarn start ```, and you can get started with designing the surveys.
 2. [Admin-Scripts](https://github.com/influenzanet/admin-scripts): Clone the repository in the link. The readme here consists of explanations of how to upload new surveys and studies to a deployed version of influenzanet. Navigate to resources/config.yaml and enter the credentials of the admin user (configured in mongo configurations). Also, add the links for the management API and participant API. (Generally https://your-domain-goes-here/admin & https://your-domain-goes-here/api ) 
 
+    ```yaml
+    management_api_url: "https://[your-domain]/admin"
+    participant_api_url: "https://[your-domain]/api"
+    user_credentials:
+    email: [admin_email]
+    password: [admin_password]
+    instanceId: belgium
+    ```
 
 ## Creating a study
 
-Studies contain surveys that are offered to participants of the study. To begin, we first create a study by following the steps below:
+Studies contain surveys that are offered to participants of the study. To begin with, we first create a study by following the steps below:
 
 1. Enter into the cloned [Admin-Scripts](https://github.com/influenzanet/admin-scripts) folder by running ``` cd study-manager-scripts ``` folder.
 2. Navigate to resources/studies/props.yaml and give the new study a key in the studyKey attribute. (Ex: influenzanet-be).
@@ -24,12 +32,16 @@ This creates the study in the platform.
 
 ## Creating and adding surveys
 
-To create a new survey make use of the [Study-Manager-App](https://github.com/influenzanet/study-manager-app) to code in your survey. A visual representation of what the survey will look like can be seen by running ```yarn start```. A detailed video describing this procedure can be found by contacting influenzanet@uhasselt.be. 
+To create a new survey make use of the [study-manager-app](https://github.com/influenzanet/study-manager-app) to code in your survey. A visual representation of what the survey will look like can be seen by running ```yarn start```. A detailed video describing this procedure can be found by contacting influenzanet@uhasselt.be. 
 
 Once the questions have been coded in, you can download the surveys for intake and weekly questions by following these steps:
+
 1. Run ```yarn start```
+
 2. In the User Interface select for example the instance "belgium or bel" and select intake. Replace belgium with your instance here.
+
 3. This loads the visual representation of the intake survey. Scroll to the bottom, enter the studykey "influenzanet-be" (or what you set previously while creating a study) and click download.
+
 4. Repeat step 3 for weekly surveys.
 
 This should give you 2 surveys that you then need to copy into the resources/surveys folder of the locally cloned [Admin-Scripts](https://github.com/influenzanet/admin-scripts) repository.
@@ -37,9 +49,12 @@ This should give you 2 surveys that you then need to copy into the resources/sur
 Once these files have been copied, run the following:
 1. To upload the intake survey, ```python run_save_survey.py --study_key <your-study-key> --survey_json resources/study/<downloaded-intake-file-name>.json ```
 2. To upload the weekly survey, ```python run_save_survey.py --study_key <your-study-key> --survey_json resources/study/<downloaded-weekly-file-name>.json ```
-3. Lastly upload the migration survey (needed for some internal configuration), by running ```python run_save_survey.py --study_key <your-study-key> --survey_json resources/study/nl-migration.json ``` (this file is already present in the folder)
-
-With these steps completed, a logged-in user should see the intake survey. Weekly surveys will show up once the intake has been filled.
 
 
-NOTE: To make updates to the intake or weekly questionnaire, repeat the entire process and reupload the surveys using the same scripts.
+With these steps completed, a logged-in user should see the intake survey. Weekly surveys will show up once the intake has been filled, on the configured day of the week.
+
+When adding new surveys (eg: vaccination surveys) the same steps must be followed.
+
+To make updates to the intake or weekly questionnaire (or to any other survey), repeat the entire process and re-upload the surveys using the same scripts.
+
+**Next**: [Setting up Emails](../system-configuration/3-email-setup.md)

--- a/system-configuration/2-create-study-surveys.md
+++ b/system-configuration/2-create-study-surveys.md
@@ -6,8 +6,8 @@ Influenzanet is firstly a survey platform. This section explains the steps invol
 
 To create, and upload studies and surveys you need to configure two repositories on a local machine:
 
-1. [Study-Manager-App](https://github.com/influenzanet/study-manager-app): Clone the repository in the link. Install the required dependencies by running ``` yarn start ```, and you can get started with designing the surveys.
-2. [Admin-Scripts](https://github.com/influenzanet/admin-scripts): Clone the repository in the link. The readme here consists of explanations of how to upload new surveys and studies to a deployed version of influenzanet. Navigate to resources/config.yaml and enter the credentials of the admin user (configured in mongo configurations). Also, add the links for the management API and participant API. (Generally https://your-domain-goes-here/admin & https://your-domain-goes-here/api ) 
+1. [study-manager-app](https://github.com/influenzanet/study-manager-app): Clone the repository in the link. Install the required dependencies by running ``` yarn start ```, and you can get started with designing the surveys.
+2. [admin-scripts](https://github.com/influenzanet/admin-scripts): Clone the repository in the link. The readme here consists of explanations of how to upload new surveys and studies to a deployed version of influenzanet. Navigate to resources/config.yaml and enter the credentials of the admin user (configured in mongo configurations). Also, add the links for the management API and participant API. (Generally https://your-domain-goes-here/admin & https://your-domain-goes-here/api ) 
 
     ```yaml
     management_api_url: "https://[your-domain]/admin"
@@ -22,7 +22,7 @@ To create, and upload studies and surveys you need to configure two repositories
 
 Studies contain surveys that are offered to participants of the study. To begin with, we first create a study by following the steps below:
 
-1. Enter into the cloned [Admin-Scripts](https://github.com/influenzanet/admin-scripts) folder by running ``` cd study-manager-scripts ``` folder.
+1. Enter into the cloned [admin-scripts](https://github.com/influenzanet/admin-scripts) folder by running ``` cd study-manager-scripts ``` folder.
 2. Navigate to resources/studies/props.yaml and give the new study a key in the studyKey attribute. (Ex: influenzanet-be).
 3. In the resources/studies/study_def.yaml you can change the translations that show up describing the study as suited to you.
 4. In the resources/studies/study_rules.yaml you can change configure how frequently the different surveys show up. But generally leave this file untouched.
@@ -44,7 +44,7 @@ Once the questions have been coded in, you can download the surveys for intake a
 
 4. Repeat step 3 for weekly surveys.
 
-This should give you 2 surveys that you then need to copy into the resources/surveys folder of the locally cloned [Admin-Scripts](https://github.com/influenzanet/admin-scripts) repository.
+This should give you 2 surveys that you then need to copy into the resources/surveys folder of the locally cloned [admin-scripts](https://github.com/influenzanet/admin-scripts) repository.
 
 Once these files have been copied, run the following:
 1. To upload the intake survey, ```python run_save_survey.py --study_key <your-study-key> --survey_json resources/study/<downloaded-intake-file-name>.json ```

--- a/system-configuration/3-email-setup.md
+++ b/system-configuration/3-email-setup.md
@@ -32,7 +32,7 @@ Use the examples as a guide to understand what variables are needed, and also re
 
 In addition, a weekly email template is also needed to send survey reminders to participants once every week. The example for this exists in the folder resources/auto_reminder_email (one for each language supported). 
 
-## Uploading the templates to influenzanet
+## Uploading the templates to Influenzanet
 
 After creating a fresh email template or updating (in case of changes) an existing one in the [admin-scripts](https://github.com/influenzanet/admin-scripts) repository, follow these steps:
 

--- a/system-configuration/3-email-setup.md
+++ b/system-configuration/3-email-setup.md
@@ -88,4 +88,4 @@ After creating a fresh email template or updating (in case of changes) an existi
     
     2.5. To upload the weekly reminder run the following script:  ``` python run_create_auto_mail.py ```
    
-**Next**: [When To Redeploy Changes](../redeploying-changes/1-change-types.md)
+**Next**: [Configuring the Web Front End](../system-configuration/4-web-config.md)

--- a/system-configuration/3-email-setup.md
+++ b/system-configuration/3-email-setup.md
@@ -25,7 +25,7 @@ Clone the private repository [admin-scripts](https://github.com/influenzanet/adm
 
 ## Creating E-mail templates
 
-For each of the e-mail types, a template needs to be created. Additionally each template needs to have copies in different languages intended to be supported by the platform. An example of this can be found in the resources/email_templates folder of the [Study-Manager-Scripts](https://github.com/influenzanet/study-manager-scripts) repository. You can chose to use the same (with changes to the logo's and content) or you can create fresh templates.
+For each of the e-mail types, a template needs to be created. Additionally each template needs to have copies in different languages intended to be supported by the platform. An example of this can be found in the resources/email_templates folder of the [admin-scripts](https://github.com/influenzanet/admin-scripts) repository. You can chose to use the same (with changes to the logo's and content) or you can create fresh templates.
 
 Along with the content of each email, there are also certain variables that need to be configured. (For ex to insert the login code for 2FA in the verification code email: ```{{index . "verificationCode"}}```). 
 Use the examples as a guide to understand what variables are needed, and also refer to the variables listed in the [email-template guide](https://github.com/influenzanet/messaging-service/blob/master/docs/email-templates.md). 

--- a/system-configuration/3-email-setup.md
+++ b/system-configuration/3-email-setup.md
@@ -36,7 +36,7 @@ In addition, a weekly email template is also needed to send survey reminders to 
 
 After creating a fresh email template or updating (in case of changes) an existing one in the [admin-scripts](https://github.com/influenzanet/admin-scripts) repository, follow these steps:
 
-1. **Uploading email-templates**: Ensure that all the sets of emails are place under a folder named with the language-code (ex: en). This folder should reside within resources/email_templates. An example is already available for the de-be, en, fr-be, and nl-be codes. Along with the emails there should also be a file called subjects.yaml containing the following:
+1. **Uploading email-templates**: Ensure that all the sets of emails are place under a folder named with the language-code (eg: en). This folder should reside within resources/email_templates. An example is already available for the de-be, en, fr-be, and nl-be codes. Along with the emails there should also be a file called subjects.yaml containing the following:
 
     ```yaml
     account-deleted: "Your account has been successfully deleted"

--- a/system-configuration/3-email-setup.md
+++ b/system-configuration/3-email-setup.md
@@ -1,8 +1,8 @@
 # Setting up Emails 
 
-This section deals with the kinds of email templates needed and how to upoad them to a running instance of influenzanet.
+This section deals with the kinds of email templates needed and how to upload them to a running instance of Influenzanet.
 
-influenzanet uses the following email templates:
+Influenzanet uses the following email templates:
 
 | Email Name       | Purpose  |
 | -------------- | :----------------:|
@@ -16,11 +16,11 @@ influenzanet uses the following email templates:
 | **account-deleted**| as a last contact, this message will be sent out to confirm the successful account deletion|
 
 
-NOTE: One additional type of email is the weekly reminder email. 
+**NOTE**: One additional type of email is the weekly reminder email. 
 
 ## Pre-requisites
 
-1. [Study-Manager-Scripts](https://github.com/influenzanet/study-manager-scripts): Clone the repository in the link. The readme here consists of explanations of how to upload new surveys and studies to a deployed version of influenzanet. Navigate to resources/config.yaml and enter the credentials of admin user (configured in mongo configurations). Also add the links for the management api and participant api. (Generally https://your-domain-goes-here/admin & https://your-domain-goes-here/api ) 
+Clone the private repository [admin-scripts](https://github.com/influenzanet/admin-scripts). The ```readme.md``` file inside the [study-manager-scripts](https://github.com/influenzanet/admin-scripts/tree/master/study-manager-scripts) folder contains explanations on how to upload new surveys and studies to a deployed version of influenzanet. 
 
 
 ## Creating E-mail templates
@@ -28,16 +28,17 @@ NOTE: One additional type of email is the weekly reminder email.
 For each of the e-mail types, a template needs to be created. Additionally each template needs to have copies in different languages intended to be supported by the platform. An example of this can be found in the resources/email_templates folder of the [Study-Manager-Scripts](https://github.com/influenzanet/study-manager-scripts) repository. You can chose to use the same (with changes to the logo's and content) or you can create fresh templates.
 
 Along with the content of each email, there are also certain variables that need to be configured. (For ex to insert the login code for 2FA in the verification code email: ```{{index . "verificationCode"}}```). 
-Use the examples as a guide to understand what variables are needed, and also refer to the variables listed in the [email-template guide](https://github.com/influenzanet/messaging-service/edit/master/docs/email-templates.md). 
+Use the examples as a guide to understand what variables are needed, and also refer to the variables listed in the [email-template guide](https://github.com/influenzanet/messaging-service/blob/master/docs/email-templates.md). 
 
 In addition, a weekly email template is also needed to send survey reminders to participants once every week. The example for this exists in the folder resources/auto_reminder_email (one for each language supported). 
 
 ## Uploading the templates to influenzanet
 
-After creating a fresh email template or updating (in case of changes) an existing one in the [Study-Manager-Scripts](https://github.com/influenzanet/study-manager-scripts) repository, follow these steps:
+After creating a fresh email template or updating (in case of changes) an existing one in the [admin-scripts](https://github.com/influenzanet/admin-scripts) repository, follow these steps:
 
 1. **Uploading email-templates**: Ensure that all the sets of emails are place under a folder named with the language-code (ex: en). This folder should reside within resources/email_templates. An example is already available for the de-be, en, fr-be, and nl-be codes. Along with the emails there should also be a file called subjects.yaml containing the following:
-    ```
+
+    ```yaml
     account-deleted: "Your account has been successfully deleted"
     account-id-changed: "Your email address has been changed"
     password-changed: "Your password has been changed"
@@ -48,11 +49,14 @@ After creating a fresh email template or updating (in case of changes) an existi
     verify-email: "Confirm email address"
     weekly: "Your weekly questionnaire is ready for you"
     ```
+
     1.1. Create a copy of this file under each language code, containing the translations for the email subject for each language. (the key remains the same, only the value is translated)
+    
     1.2. Once this is done, to upload the email-templates run ``` python run_email_template_uploader.py ``` from the root of the repository.
-<br/>
+
 2. **Uploading Weekly reminders**: Save each language version of the weekly reminder as language-code.html within the resources/auto_reminder_email folder. Additionally, also create a settings.yaml file here with the following content:
-    ```
+
+    ```yaml
     sendTo: "all-users"
     studyKey: "influenzanet-be"
     messageType: "weekly"
@@ -73,8 +77,15 @@ After creating a fresh email template or updating (in case of changes) an existi
         subject: "Ihre wöchentliche Frageliste ist fertig"
         templateFile: "de-be.html"
     ```
+    
     2.1. Configure the study-key here
+    
     2.2. sendTo: "all-users" indicates that this mail needs to be sent to all users in the system.
+    
     2.3. nextTime: Indicates the next time emails are sent after this new version of the weekly emails are uploaded. (Always keep this to a future date)
+    
     2.4. Configure the Subject of the emails for each language as shown in the example above.
-    2.5. To upload the weekly reminder run the following script: ``` python run_create_auto_mail.py ```
+    
+    2.5. To upload the weekly reminder run the following script:  ``` python run_create_auto_mail.py ```
+   
+**Next**: [When To Redeploy Changes](../redeploying-changes/1-change-types.md)

--- a/system-configuration/4-web-config.md
+++ b/system-configuration/4-web-config.md
@@ -19,4 +19,4 @@ To get started, the example-public-folder contains example configurations within
 4.2. **header**: Set the logo image and styles used in the header here.
 4.3. **Navbar**: Set the items and the URL's they map on the navigation bar. This also includes the items that show up under the user dropdown on the right corner of the navbar.
 4.4. **Footer**: Configure the columns and links in the footer section.
-4.5. **Pages**: Contains an array of the different pages of the webapp. Here you can map a url to a page, and set the layout, contents, elements and styles for each page item. Note: "pageKey" is used to map to a file in locales to render the labels for the elements of the page in each language. "itemkey" defines the name to be looked for in the file defined by "pageKey".
+4.5. **Pages**: Contains an array of the different pages of the webapp. Here you can map a url to a page, and set the layout, contents, elements and styles for each page item. **NOTE**: "pageKey" is used to map to a file in locales to render the labels for the elements of the page in each language. "itemkey" defines the name to be looked for in the file defined by "pageKey".

--- a/system-configuration/4-web-config.md
+++ b/system-configuration/4-web-config.md
@@ -3,20 +3,34 @@
 
 ## Web UI configuration
 
-Start by creating a fork of the Influenzanet/participant-webapp repo in your local organisation or create a local copy of this repository.
+Start by creating a fork of the Influenzanet [participant-webapp](https://github.com/influenzanet/participant-webapp) repository in your local organization or create a local copy of this repository.
 
-The participant webapp is a configurable front end that relies on json/ts configurations to dynamically adapt the layouts of the different pages on the user interface. The confugrations are split into two main parts:
-1. Application level config: Contained in public/assets/configs. Consists on application level settings like languages supported, header, footer, and page layouts.
-2. Locale level config: Contained within public/assets/locales. Consists of language specific labels organised according to the different pages set in the application level config.
+The participant webapp is a configurable front end that relies on ```json```/```ts``` configurations to dynamically adapt the layouts of the different pages on the user interface. The confugrations are split into two main parts:
 
-To get started, the example-public-folder contains example configurations within the assets folder. Create a copy of this folder and rename it to **public**. Then, perform the following changes: 
+1. Application level config: Contained in ```public/assets/configs```. Consists on application level settings like languages supported, header, footer, and page layouts.
 
-1. Update the public/assets/locales to add folders for each supported language.
+2. Locale level config: Contained within ```public/assets/locales```. Consists of language specific labels organised according to the different pages set in the application level config.
+
+To get started, the example-public-folder contains example configurations within the assets folder. Create a copy of this folder and rename it to ```public```. Then, perform the following changes: 
+
+1. Update the ```public/assets/locales``` to add folders for each supported language.
+
 2. Configure the keys, markdown content within the locales folders.
-3. Upload additional images needed into the public/assets/images folder.
-4. Configure page layouts, headers, and footers by configuring the files present in public/assets/configs.
-4.1. **Appconfig**: Set the language codes for the supported languages here. Also configure the avatars available for user profiles here.
-4.2. **header**: Set the logo image and styles used in the header here.
-4.3. **Navbar**: Set the items and the URL's they map on the navigation bar. This also includes the items that show up under the user dropdown on the right corner of the navbar.
-4.4. **Footer**: Configure the columns and links in the footer section.
-4.5. **Pages**: Contains an array of the different pages of the webapp. Here you can map a url to a page, and set the layout, contents, elements and styles for each page item. **NOTE**: "pageKey" is used to map to a file in locales to render the labels for the elements of the page in each language. "itemkey" defines the name to be looked for in the file defined by "pageKey".
+
+3. Upload additional images needed into the ```public/assets/images``` folder.
+
+4. Configure page layouts, headers, and footers by configuring the files present in ```public/assets/configs```.
+
+    4.1. **Appconfig**: Set the language codes for the supported languages here. Also configure the avatars available for user profiles here.
+
+    4.2. **header**: Set the logo image and styles used in the header here.
+
+    4.3. **Navbar**: Set the items and the URL's they map on the navigation bar. This also includes the items that show up under the user dropdown on the right corner of the navbar.
+
+    4.4. **Footer**: Configure the columns and links in the footer section.
+
+    4.5. **Pages**: Contains an array of the different pages of the webapp. Here you can map a url to a page, and set the layout, contents, elements and styles for each page item. 
+    
+    **NOTE**: "pageKey" is used to map to a file in locales to render the labels for the elements of the page in each language. "itemkey" defines the name to be looked for in the file defined by "pageKey".
+
+**Next**: [Configuring the mail server](../system-configuration/5-mailing-config.md)

--- a/system-configuration/5-mailing-config.md
+++ b/system-configuration/5-mailing-config.md
@@ -12,7 +12,7 @@ This sections walks through the configurations needed to connect an emailing ser
         - Password to connect with.
 2. Some mailing services might also need additional configurations to be made with the dns provider. These include registering the domain to be used with Influenzanet, and creating additional records within the dns settings. All mailing services have their requirements and generally have guides to help configure these.
 
-NOTE: This configuration can be skipped if the configuration changes are made to cluster-management as mentioned in the [readme](https://github.com/influenzanet/cluster-management/blob/master/README.md) before running the install script.
+**NOTE**: This configuration can be skipped if the configuration changes are made to cluster-management as mentioned in the [readme](https://github.com/influenzanet/cluster-management/blob/master/README.md) before running the install script.
 
 ### Configuration
 

--- a/system-configuration/5-mailing-config.md
+++ b/system-configuration/5-mailing-config.md
@@ -10,6 +10,7 @@ This sections walks through the configurations needed to connect an emailing ser
     - Authentication information
         - User name or email to use
         - Password to connect with.
+        
 2. Some mailing services might also need additional configurations to be made with the dns provider. These include registering the domain to be used with Influenzanet, and creating additional records within the dns settings. All mailing services have their requirements and generally have guides to help configure these.
 
 **NOTE**: This configuration can be skipped if the configuration changes are made to cluster-management as mentioned in the [readme](https://github.com/influenzanet/cluster-management/blob/master/README.md) before running the install script.
@@ -18,7 +19,9 @@ This sections walks through the configurations needed to connect an emailing ser
 
 After running the installation scripts, perform the following: 
 1. Navigate to Kubernetes > Configuration
+
 2. Select email-server-config, and click edit.
+
 3. Ensure that the following fields are correctly updated for both "high-prio-smtp-servers.yaml" and "smtp-servers.yaml"
     - from: What users see as the from address when receiving Influenzanet mails.
     - sender: Email address of the sender(from can be a name as well)
@@ -27,4 +30,7 @@ After running the installation scripts, perform the following:
         - host: SMTP host
         - port: SMTP port
         - auth: contains the username and password credentials for the mailing service.
+
 4. Save to update.
+
+**Next**: [When To Redeploy Changes](../redeploying-changes/1-change-types.md)

--- a/system-configuration/5-mailing-config.md
+++ b/system-configuration/5-mailing-config.md
@@ -1,6 +1,6 @@
 # Mailing Configuration
 
-This sections walks through the configurations needed to connect an emailing service to the influenzanet platform. Currently the platform only supports SMTP, so the mailing service chosen needs to behave as an SMTP relay gateway.
+This sections walks through the configurations needed to connect an emailing service to the Influenzanet platform. Currently the platform only supports SMTP, so the mailing service chosen needs to behave as an SMTP relay gateway.
 
 ## Pre-requisites
 
@@ -10,7 +10,7 @@ This sections walks through the configurations needed to connect an emailing ser
     - Authentication information
         - User name or email to use
         - Password to connect with.
-2. Some mailing services might also need additional configurations to be made with the dns provider. These include registering the domain to be used with influenzanet, and creating additional records within the dns settings. All mailing services have their requirements and generally have guides to help configure these.
+2. Some mailing services might also need additional configurations to be made with the dns provider. These include registering the domain to be used with Influenzanet, and creating additional records within the dns settings. All mailing services have their requirements and generally have guides to help configure these.
 
 NOTE: This configuration can be skipped if the configuration changes are made to cluster-management as mentioned in the [readme](https://github.com/influenzanet/cluster-management/blob/master/README.md) before running the install script.
 
@@ -20,7 +20,7 @@ After running the installation scripts, perform the following:
 1. Navigate to Kubernetes > Configuration
 2. Select email-server-config, and click edit.
 3. Ensure that the following fields are correctly updated for both "high-prio-smtp-servers.yaml" and "smtp-servers.yaml"
-    - from: What users see as the from address when receiving influenzanet mails.
+    - from: What users see as the from address when receiving Influenzanet mails.
     - sender: Email address of the sender(from can be a name as well)
     - replyTo: additional addresses to always send emails to (can be an empty array)
     - servers: consists of configurations to be set from the mailing service (obtained in pre-requisites): [Array type]


### PR DESCRIPTION
First pass of the documentation review. 

Main change is in dbd33f5, adding instructions to verify and disable 2FA for the admin user. 

Should now be self-consistent even if a bit scarce in some places and lead to a working deployment if followed from start to finish. 

Minor changes:
- [x] typos
- [x] Influenzanet vs influenzanet
  the former for the project, the latter for the repository
- [x] GitHub instead github
- [x] Dockerhub instead of dockerhub
- [x] Kubernetes instead kubernetes
- [x] eg: instead of ex:
- [x] add links to next step
- [x] check that links are working
- [x] use **NOTE**: everywhere
- [x] use relative repo links where useful
- [x] correctly format each source block: sh, yaml, ...
